### PR TITLE
PC-1631 By default encrypt all object in S3 bucket with SSE-S3

### DIFF
--- a/modules/aws/nobl9/main.tf
+++ b/modules/aws/nobl9/main.tf
@@ -1,6 +1,13 @@
 resource "aws_s3_bucket" "nobl9_exporter_bucket" {
   bucket = var.s3_bucket_name
   tags   = var.tags
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "block_all_public_access" {


### PR DESCRIPTION
Supporting all possible ways for encryption of S3 bucket in a configurable manner is more challenging and time-consuming:
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#enable-default-server-side-encryption

Hence as quick win introduce [Server-side encryption Amazon S3 master-key (SSE-S3)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) for created S3 bucket which is free and doesn't require any configuration from user.
