### PR TITLE
PC-1631 Set object ownership to bucket owner preferred

### DIFF
--- a/modules/aws/nobl9/main.tf
+++ b/modules/aws/nobl9/main.tf
@@ -18,6 +18,14 @@ resource "aws_s3_bucket_public_access_block" "block_all_public_access" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_owner_ownership" {
+  bucket = aws_s3_bucket.nobl9_exporter_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+  depends_on = [aws_s3_bucket_public_access_block.block_all_public_access]
+}
+
 data "aws_iam_policy_document" "access_to_s3" {
   statement {
     effect = "Allow"


### PR DESCRIPTION
As described in section `Setting S3 Object Ownership` of [this documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html).
Explicit `depends_on` is used due to known limitation https://github.com/hashicorp/terraform-provider-aws/issues/7628#issuecomment-799533569