### PR TITLE
PC-5742 PC-5798 Data export - add objective_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ the database. Steps related to Snowflake have to be performed in its UI.
       slo_time_window_duration_count int not null,
       slo_time_window_start_time timestamp_tz,
       composite boolean,
-      objective_name string,
+      objective_name string
     );
     ```
 


### PR DESCRIPTION
## Motivation

This PR aims to introduce changes needed to resolve [PC-5742](https://nobl9.atlassian.net/browse/PC-5742).

## Insight

While adding column to new tables is nothing more than adjusting the table schema, it's a whole different ordeal for already existing Snowflake integrations. In order to support this change, several steps are necessary:

```sql
-- 1. Adjust nobl9_csv_format to prevents error in case of too few columns or too many columns, depending on the time of the migration.

create or replace file format nobl9_csv_format
  type = csv
  field_delimiter = ','
  skip_header = 1
  null_if = ('NULL', 'null')
  empty_field_as_null = true
  field_optionally_enclosed_by = '"'
  error_on_column_count_mismatch = false 
  compression = gzip;

-- 2. Re-create existing s3_export_stage to support updated file_format.

create or replace stage s3_export_stage
  url = 's3://<BUCKET_NAME>'
  file_format = nobl9_csv_format
  storage_integration = nobl9_s3;

-- 3. Re-create existing pipe to support updated stage.

create or replace pipe nobl9_data_pipe auto_ingest=true as
  copy into nobl9_data
    from @s3_export_stage;
    
-- 4. Rename column to match its contents.

alter table nobl9_data rename column objective_name to objective_display_name;

-- 5. Add new column with objectives names.

alter table nobl9_data add column objective_name string;

```